### PR TITLE
Further relax ActiveSupport requirement to support Rails > 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,5 @@ end
 group :test do
 end
 
-gem "activesupport", '~> 3.0' # for OrderedHash
+gem "activesupport", "> 2.1.0" # for OrderedHash
 gem "capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 3.0)
+  activesupport (> 2.1.0)
   bundler (~> 1.1.0)
   capybara
   jeweler (~> 1.8.3)

--- a/capybara-page-object.gemspec
+++ b/capybara-page-object.gemspec
@@ -4,14 +4,14 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = %q{capybara-page-object}
+  s.name = "capybara-page-object"
   s.version = "0.6.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = [%q{Andy Waite}]
-  s.date = %q{2012-04-22}
-  s.description = %q{Page Objects for Capybara}
-  s.email = %q{andy@andywaite.com}
+  s.authors = ["Andy Waite"]
+  s.date = "2012-07-24"
+  s.description = "Page Objects for Capybara"
+  s.email = "andy@andywaite.com"
   s.extra_rdoc_files = [
     "LICENSE.txt",
     "README.markdown"
@@ -73,17 +73,17 @@ Gem::Specification.new do |s|
     "spec/node_spec.rb",
     "spec/page_spec.rb"
   ]
-  s.homepage = %q{http://github.com/andyw8/capybara-page-object}
-  s.licenses = [%q{MIT}]
-  s.require_paths = [%q{lib}]
-  s.rubygems_version = %q{1.8.6}
-  s.summary = %q{Page Objects for Capybara}
+  s.homepage = "http://github.com/andyw8/capybara-page-object"
+  s.licenses = ["MIT"]
+  s.require_paths = ["lib"]
+  s.rubygems_version = "1.8.23"
+  s.summary = "Page Objects for Capybara"
 
   if s.respond_to? :specification_version then
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<activesupport>, ["~> 3.0"])
+      s.add_runtime_dependency(%q<activesupport>, ["> 2.1.0"])
       s.add_runtime_dependency(%q<capybara>, [">= 0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.1.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.8.3"])
@@ -92,7 +92,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<rake>, ["~> 0.9.2.2"])
       s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
     else
-      s.add_dependency(%q<activesupport>, ["~> 3.0"])
+      s.add_dependency(%q<activesupport>, ["> 2.1.0"])
       s.add_dependency(%q<capybara>, [">= 0"])
       s.add_dependency(%q<bundler>, ["~> 1.1.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.8.3"])
@@ -102,7 +102,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<rdoc>, ["~> 3.12"])
     end
   else
-    s.add_dependency(%q<activesupport>, ["~> 3.0"])
+    s.add_dependency(%q<activesupport>, ["> 2.1.0"])
     s.add_dependency(%q<capybara>, [">= 0"])
     s.add_dependency(%q<bundler>, ["~> 1.1.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.8.3"])


### PR DESCRIPTION
The `activesupport` gem can be rolled all the way back to `2.1.0` before the tests break. In the interest of supporting users of older versions of Rails, I've relaxed the requirement.
